### PR TITLE
website: Remove broken links from sidebar nav

### DIFF
--- a/website/checkpoint.erb
+++ b/website/checkpoint.erb
@@ -13,7 +13,7 @@
         <li<%= sidebar_current("docs-checkpoint-resource") %>>
         <a href="#">Resources</a>
           <ul class="nav nav-visible">
-          
+
             <li<%= sidebar_current("docs-checkpoint-resource-checkpoint-management-discard") %>>
               <a href="/docs/providers/checkpoint/r/checkpoint_management_discard.html">checkpoint_management_discard</a>
             </li>
@@ -126,10 +126,6 @@
               <a href="/docs/providers/checkpoint/r/checkpoint_management_export.html">checkpoint_management_export</a>
             </li>
 
-            <li<%= sidebar_current("docs-checkpoint-resource-checkpoint-management-put-file") %>>
-              <a href="/docs/providers/checkpoint/r/checkpoint_management_put_file.html">checkpoint_management_put_file</a>
-            </li>
-
             <li<%= sidebar_current("docs-checkpoint-resource-checkpoint-management-where-used") %>>
               <a href="/docs/providers/checkpoint/r/checkpoint_management_where_used.html">checkpoint_management_where_used</a>
             </li>
@@ -182,10 +178,6 @@
               <a href="/docs/providers/checkpoint/r/checkpoint_management_group_with_exclusion.html">checkpoint_management_group_with_exclusion</a>
             </li>
 
-            <li<%= sidebar_current("docs-checkpoint-resource-checkpoint-management-simple-cluster") %>>
-              <a href="/docs/providers/checkpoint/r/checkpoint_management_simple_cluster.html">checkpoint_management_simple_cluster</a>
-            </li>
-
             <li<%= sidebar_current("docs-checkpoint-resource-checkpoint-management-security-zone") %>>
               <a href="/docs/providers/checkpoint/r/checkpoint_management_security_zone.html">checkpoint_management_security_zone</a>
             </li>
@@ -200,10 +192,6 @@
 
             <li<%= sidebar_current("docs-checkpoint-resource-checkpoint-management-dynamic-object") %>>
               <a href="/docs/providers/checkpoint/r/checkpoint_management_dynamic_object.html">checkpoint_management_dynamic_object</a>
-            </li>
-
-            <li<%= sidebar_current("docs-checkpoint-resource-checkpoint-management-tag") %>>
-              <a href="/docs/providers/checkpoint/r/checkpoint_management_tag.html">checkpoint_management_tag</a>
             </li>
 
             <li<%= sidebar_current("docs-checkpoint-resource-checkpoint-management-dns-domain") %>>
@@ -302,14 +290,10 @@
               <a href="/docs/providers/checkpoint/r/checkpoint_management_https_layer.html">checkpoint_management_https_layer</a>
             </li>
 
-            <li<%= sidebar_current("docs-checkpoint-resource-checkpoint-management-server-certificate") %>>
-              <a href="/docs/providers/checkpoint/r/checkpoint_management_server_certificate.html">checkpoint_management_server_certificate</a>
-            </li>
-
             <li<%= sidebar_current("docs-checkpoint-resource-checkpoint-hostname") %>>
               <a href="/docs/providers/checkpoint/r/checkpoint_hostname.html">checkpoint_hostname</a>
             </li>
-			
+
 			<li<%= sidebar_current("docs-checkpoint-resource-checkpoint-physical-interface") %>>
               <a href="/docs/providers/checkpoint/r/checkpoint_physical_interface.html">checkpoint_physical_interface</a>
             </li>
@@ -321,7 +305,7 @@
             <li<%= sidebar_current("docs-checkpoint-resource-checkpoint-management-package") %>>
               <a href="/docs/providers/checkpoint/r/checkpoint_management_package.html">checkpoint_management_package</a>
             </li>
-			
+
 			<li<%= sidebar_current("docs-checkpoint-resource-checkpoint-management-login") %>>
               <a href="/docs/providers/checkpoint/r/checkpoint_management_login.html">checkpoint_management_login</a>
             </li>
@@ -329,7 +313,7 @@
 			<li<%= sidebar_current("docs-checkpoint-resource-checkpoint-management-publish") %>>
               <a href="/docs/providers/checkpoint/r/checkpoint_management_publish.html">checkpoint_management_publish</a>
             </li>
-			
+
 			<li<%= sidebar_current("docs-checkpoint-resource-checkpoint-management-install-policy") %>>
               <a href="/docs/providers/checkpoint/r/checkpoint_management_install_policy.html">checkpoint_management_install_policy</a>
             </li>


### PR DESCRIPTION
These broken links are causing the terraform.io website build jobs to exit with a failing status. 

This PR only removes the links to nowhere; **it doesn't actually fix the underlying problem.** Which is:

- The following pages are orphaned (not linked from the sidebar): 
    - `checkpoint_hostname`
    - `checkpoint_management_install_policy`
    - `checkpoint_management_login`
    - `checkpoint_management_logout`
    - `checkpoint_management_policy_package`
    - `checkpoint_management_publish`
    - `checkpoint_management_run_ips_update`
    - `checkpoint_physical_interface`
    - `checkpoint_put_file`
- The following resources (as declared in provider.go) do not have docs pages: 
    - `checkpoint_management_put_file`
- The following docs pages are for resources that are no longer declared in provider.go: 
    - `checkpoint_hostname`
    - `checkpoint_management_install_policy`
    - `checkpoint_management_login`
    - `checkpoint_management_logout`
    - `checkpoint_management_policy_package`
    - `checkpoint_management_publish`
    - `checkpoint_management_run_ips_update`
    - `checkpoint_physical_interface`
    - `checkpoint_put_file`

Where would you like tasks created for dealing with all that?
